### PR TITLE
Add reference to "Building C2 Implants in C++"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ cd build
 cmake ..
 make
 ```
+
+# Related Work
+
+- The book "[Building C2 Implants in C++: A Primer](https://shogunlab.gitbook.io/building-c2-implants-in-cpp-a-primer/)" discusses a variant of this implant in [Chapter 3: Basic Implant & Tasking](https://shogunlab.gitbook.io/building-c2-implants-in-cpp-a-primer/chapter-3-basic-implant-and-tasking).


### PR DESCRIPTION
Adds section "Related Work" to README and references the "Building C2 Implants in C++" book where a modified version of the "cpp-implant" code is featured throughout Chapter 3.